### PR TITLE
Add tests and enable Packit CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,13 @@
+jobs:
+- job: tests
+  trigger: pull_request
+  targets:
+    centos-stream-9-x86_64:
+      distros: [RHEL-9.2.0-Nightly]
+  use_internal_tf: True
+  skip_build: true
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            target_PR_branch: "main"

--- a/functional/basic-attestation-on-containers/main.fmf
+++ b/functional/basic-attestation-on-containers/main.fmf
@@ -1,0 +1,36 @@
+summary: Tests basic keylime attestation scenario for keylime ansible roles in container.
+description: |
+    Running only tenant on localhost. Verifier and Registrar run in container and agents run in container.
+    Create new network for containers.
+    Build container image with verifier and registrar.
+    Run verifier and registrar container.
+    Download ansible playbook for keylime verifier and registrar roles.
+    Run ansible playbook to set up verifier and registrar in container.
+    Build container image with agent.
+    Setup agent conf for agent container.
+    Run container with agent.
+    Register agent by verifier.
+    Verify that container passed with agent attestation.
+contact: Patrik Koncity <pkoncity@redhat.com>
+tag:
+  - container
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+require:
+  - url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: rhel-9-main
+    name: /Library/test-helpers
+  - yum
+  - podman
+  - ansible-core
+  - nmap
+recommend:
+  - keylime
+duration: 10m
+enabled: true
+adjust:
+  - when: swtpm == yes
+    enabled: false
+    because: This tests needs TPM device since kernel boot

--- a/functional/basic-attestation-on-containers/test.sh
+++ b/functional/basic-attestation-on-containers/test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+[ -n "$DOCKERFILE_AGENT" ] || DOCKERFILE_AGENT=Dockerfile.agent
+[ -n "$DOCKERFILE_SYSTEMD" ] || DOCKERFILE_SYSTEMD=Dockerfile.systemd
+
+#Machine should have /dev/tpm0 or /dev/tpmrm0 device
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+
+        rlRun 'rlImport "keylime-tests/test-helpers"'|| rlDie "cannot import /keylime-tests/test-helpers library"
+
+        rlAssertRpm keylime
+        # update /etc/keylime.conf
+        limeBackupConfig
+        CONT_NETWORK_NAME="container_network"
+        IP_ATTESTATION_SERVER="172.18.0.4"
+        IP_AGENT="172.18.0.12"
+        #create network for containers
+        rlRun "limeconCreateNetwork ${CONT_NETWORK_NAME} 172.18.0.0/16"
+
+        #build verifier container
+        TAG_ATTESTATION_SERVER="attestation_server_image"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_SYSTEMD} ${TAG_ATTESTATION_SERVER}"
+
+        #mandatory for access agent containers to tpm
+        rlRun "chmod o+rw /dev/tpmrm0"
+
+        #run verifier container
+        CONT_ATTESTATION_SERVER="attestation_container"
+        rlRun "limeconRunSystemd $CONT_ATTESTATION_SERVER $TAG_ATTESTATION_SERVER $IP_ATTESTATION_SERVER $CONT_NETWORK_NAME"
+        rlRun "rm -rf roles && mkdir roles"
+        pushd roles
+        rlRun "GIT_SSL_NO_VERIFY=1 git clone https://gitlab.cee.redhat.com/keylime/attestation_server.git"
+        popd
+        rlRun "echo 172.18.0.4" > inventory
+        rlRun "cat > playbook.yml <<EOF
+- hosts: all
+  vars:
+    attestation_server_verifier_ip: \"{{ ansible_host }}\"
+    attestation_server_registrar_ip: \"{{ ansible_host }}\"
+
+  roles:
+    - attestation_server
+EOF"
+        rlRun 'ansible-playbook --ssh-common-args "-o StrictHostKeychecking=no" -i inventory playbook.yml'
+        sleep 5
+        rlRun "rm -f /var/lib/keylime/cv_ca/*"
+        rlRun "podman cp $CONT_ATTESTATION_SERVER:/var/lib/keylime/cv_ca /var/lib/keylime/"
+
+        rlRun "limeWaitForVerifier 8881 $IP_ATTESTATION_SERVER"
+        rlRun "limeWaitForRegistrar 8891 $IP_ATTESTATION_SERVER"
+
+        # tenant
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        rlRun "limeUpdateConf tenant verifier_ip $IP_ATTESTATION_SERVER"
+        rlRun "limeUpdateConf tenant registrar_ip $IP_ATTESTATION_SERVER"
+
+        #setup of agent
+        rlRun "cp -r /var/lib/keylime/cv_ca ."
+        TAG_AGENT="agent_image"
+        CONT_AGENT="agent_container"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_AGENT} ${TAG_AGENT}"
+        rlRun "limeUpdateConf agent registrar_ip '\"$IP_ATTESTATION_SERVER\"'"
+        rlRun "limeconPrepareAgentConfdir $AGENT_ID $IP_AGENT confdir_$CONT_AGENT"
+
+        # create allowlist and excludelist
+        TESTDIR=`limeCreateTestDir`
+        rlRun "limeCreateTestLists ${TESTDIR}/*"
+
+        rlRun "limeconRunAgent $CONT_AGENT $TAG_AGENT $IP_AGENT $CONT_NETWORK_NAME $PWD/confdir_$CONT_AGENT $TESTDIR"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent"
+        rlRun -s "keylime_tenant -v $IP_ATTESTATION_SERVER  -t $IP_AGENT -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c add"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        limeconSubmitLogs
+        rlRun "limeconStop $CONT_ATTESTATION_SERVER $CONT_AGENT"
+        rlRun "limeconDeleteNetwork $CONT_NETWORK_NAME"
+        #set tmp resource manager permission to default state
+        rlRun "chmod o-rw /dev/tpmrm0"
+        limeExtendNextExcludelist $TESTDIR
+        limeSubmitCommonLogs
+        limeClearData
+        limeRestoreConfig
+    rlPhaseEnd
+
+rlJournalEnd
+

--- a/functional/basic-attestation-with-custom-certificates/main.fmf
+++ b/functional/basic-attestation-with-custom-certificates/main.fmf
@@ -1,0 +1,39 @@
+summary: Tests basic keylime attestation scenario with custom certificates for keylime ansible roles in container.
+description: |
+    Running only tenant on localhost. Verifier and Registrar run in container and agents run in container.
+    Create new network for containers.
+    Generate and sign custom certificates for keylime.
+    Build container image with verifier and registrar.
+    Run verifier and registrar container.
+    Download ansible playbook for keylime verifier and registrar roles.
+    Run ansible playbook to set up verifier and registrar with custom certificates in container.
+    Build container image with agent.
+    Setup agent conf for agent container.
+    Run container with agent.
+    Register agent by verifier.
+    Verify that container passed with agent attestation.
+contact: Patrik Koncity <pkoncity@redhat.com>
+tag:
+  - container
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+require:
+  - url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: rhel-9-main
+    name: /Library/test-helpers
+  - library(openssl/certgen)
+  - openssl
+  - yum
+  - podman
+  - ansible-core
+  - nmap
+recommend:
+  - keylime
+duration: 10m
+enabled: true
+adjust:
+  - when: swtpm == yes
+    enabled: false
+    because: This tests needs TPM device since kernel boot

--- a/functional/basic-attestation-with-custom-certificates/test.sh
+++ b/functional/basic-attestation-with-custom-certificates/test.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+[ -n "$DOCKERFILE_AGENT" ] || DOCKERFILE_AGENT=Dockerfile.agent
+[ -n "$DOCKERFILE_SYSTEMD" ] || DOCKERFILE_SYSTEMD=Dockerfile.systemd
+
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+HOSTNAME=$( hostname )
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+
+        rlRun 'rlImport "keylime-tests/test-helpers"'|| rlDie "cannot import /keylime-tests/test-helpers library"
+        rlRun 'rlImport "certgen/certgen"' || rlDie "cannot import openssl/certgen library"
+        rlAssertRpm keylime
+        # update /etc/keylime.conf
+        limeBackupConfig
+
+        CONT_NETWORK_NAME="container_network"
+        IP_ATTESTATION_SERVER="172.18.0.4"
+        CONT_ATTESTATION_SERVER="attestation_container"
+        IP_AGENT="172.18.0.12"
+        #create network for containers
+        rlRun "limeconCreateNetwork ${CONT_NETWORK_NAME} 172.18.0.0/16"
+
+        # generate TLS certificates for all
+        # we are going to use 4 certificates
+        # verifier = webserver cert used for the verifier server
+        # verifier-client = webclient cert used for the verifier's connection to registrar server
+        # registrar = webserver cert used for the registrar server
+        # tenant = webclient cert used (twice) by the tenant, running on AGENT server
+        # btw, we could live with just one key instead of generating multiple keys.. but that's just how openssl/certgen works
+        rlRun "x509KeyGen ca" 0 "Generating Root CA RSA key pair"
+        rlRun "x509KeyGen intermediate-ca" 0 "Generating Intermediate CA RSA key pair"
+        rlRun "x509KeyGen verifier" 0 "Generating verifier RSA key pair"
+        rlRun "x509KeyGen verifier-client" 0 "Generating verifier-client RSA key pair"
+        rlRun "x509KeyGen registrar" 0 "Generating registrar RSA key pair"
+        rlRun "x509KeyGen tenant" 0 "Generating tenant RSA key pair"
+        rlRun "x509SelfSign ca" 0 "Selfsigning Root CA certificate"
+        rlRun "x509CertSign --CA ca --DN 'CN = ${HOSTNAME}' -t CA --subjectAltName 'IP = 127.0.0.1' intermediate-ca" 0 "Signing intermediate CA certificate with our Root CA key"
+        rlRun "x509CertSign --CA intermediate-ca --DN 'CN = ${CONT_ATTESTATION_SERVER}' -t webserver --subjectAltName 'IP = ${IP_ATTESTATION_SERVER}' verifier" 0 "Signing verifier certificate with intermediate CA key"
+        rlRun "x509CertSign --CA intermediate-ca --DN 'CN = ${CONT_ATTESTATION_SERVER}' -t webclient --subjectAltName 'IP = ${IP_ATTESTATION_SERVER}' verifier-client" 0 "Signing verifier-client certificate with intermediate CA key"
+        rlRun "x509CertSign --CA intermediate-ca --DN 'CN = ${CONT_ATTESTATION_SERVER}' -t webserver --subjectAltName 'IP = ${IP_ATTESTATION_SERVER}' registrar" 0 "Signing registrar certificate with intermediate CA key"
+        rlRun "x509CertSign --CA intermediate-ca --DN 'CN = ${HOSTNAME}' -t webclient --subjectAltName 'IP = 127.0.0.1' tenant" 0 "Signing tenant certificate with intermediate CA key"
+
+        # copy verifier certificates to proper location
+        CERTDIR=/var/lib/keylime/certs
+        rlRun "mkdir -p $CERTDIR"
+        rlRun "cp $(x509Cert ca) $CERTDIR/cacert.pem"
+        rlRun "cp $(x509Cert intermediate-ca) $CERTDIR/intermediate-cacert.pem"
+        rlRun "cp $(x509Cert verifier) $CERTDIR/verifier-cert.pem"
+        rlRun "cp $(x509Key verifier) $CERTDIR/verifier-key.pem"
+        rlRun "cp $(x509Cert verifier-client) $CERTDIR/verifier-client-cert.pem"
+        rlRun "cp $(x509Key verifier-client) $CERTDIR/verifier-client-key.pem"
+        rlRun "cp $(x509Cert registrar) $CERTDIR/registrar-cert.pem"
+        rlRun "cp $(x509Key registrar) $CERTDIR/registrar-key.pem"
+        rlRun "cp $(x509Cert tenant) $CERTDIR/tenant-cert.pem"
+        rlRun "cp $(x509Key tenant) $CERTDIR/tenant-key.pem"
+        # assign cert ownership to keylime user if it exists
+        id keylime && rlRun "chown -R keylime:keylime $CERTDIR"
+
+        #build verifier container
+        TAG_ATTESTATION_SERVER="attestation_server_image"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_SYSTEMD} ${TAG_ATTESTATION_SERVER}"
+
+        #mandatory for access agent containers to tpm
+        rlRun "chmod o+rw /dev/tpmrm0"
+
+        #run attestation server container
+        rlRun "limeconRunSystemd $CONT_ATTESTATION_SERVER $TAG_ATTESTATION_SERVER $IP_ATTESTATION_SERVER $CONT_NETWORK_NAME '--hostname $CONT_ATTESTATION_SERVER --volume /var/lib/keylime/certs:/var/lib/keylime/certs:z'"
+
+        rlRun "rm -rf roles && mkdir roles"
+        pushd roles
+        rlRun "GIT_SSL_NO_VERIFY=1 git clone https://gitlab.cee.redhat.com/keylime/attestation_server.git"
+        popd
+        rlRun "echo 172.18.0.4" > inventory
+        rlRun "cat > playbook.yml <<EOF
+- hosts: all
+  vars:
+    attestation_server_verifier_ip: \"{{ ansible_host }}\"
+    attestation_server_registrar_ip: \"{{ ansible_host }}\"
+
+    attestation_server_verifier_tls_dir: ${CERTDIR}
+    attestation_server_verifier_trusted_server_ca: [ intermediate-cacert.pem, cacert.pem]
+    attestation_server_verifier_trusted_client_ca: [ intermediate-cacert.pem, cacert.pem]
+    attestation_server_verifier_server_cert: verifier-cert.pem
+    attestation_server_verifier_server_key: verifier-key.pem
+    attestation_server_verifier_client_cert: ${CERTDIR}/verifier-client-cert.pem
+    attestation_server_verifier_client_key:  ${CERTDIR}/verifier-client-key.pem
+
+    attestation_server_registrar_tls_dir: ${CERTDIR}
+    attestation_server_registrar_trusted_client_ca: [ intermediate-cacert.pem, cacert.pem]
+    attestation_server_registrar_server_cert: registrar-cert.pem
+    attestation_server_registrar_server_key: registrar-key.pem
+
+
+  roles:
+    - attestation_server
+EOF"
+
+        rlRun 'ansible-playbook --ssh-common-args "-o StrictHostKeychecking=no" -i inventory playbook.yml'
+        sleep 5
+
+        rlRun "limeWaitForVerifier 8881 $IP_ATTESTATION_SERVER"
+        rlRun "limeWaitForRegistrar 8891 $IP_ATTESTATION_SERVER"
+
+        # tenant
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        rlRun "limeUpdateConf tenant verifier_ip $IP_ATTESTATION_SERVER"
+        rlRun "limeUpdateConf tenant registrar_ip $IP_ATTESTATION_SERVER"
+        rlRun "limeUpdateConf tenant tls_dir $CERTDIR"
+        rlRun "limeUpdateConf tenant trusted_server_ca '[\"intermediate-cacert.pem\", \"cacert.pem\"]'"
+        rlRun "limeUpdateConf tenant client_cert tenant-cert.pem"
+        rlRun "limeUpdateConf tenant client_key tenant-key.pem"
+
+        rlRun "cp $CERTDIR/cacert.pem /var/lib/keylime/cv_ca"
+        rlRun "cp -r /var/lib/keylime/cv_ca ."
+        #setup of agent
+        TAG_AGENT="agent_image"
+        CONT_AGENT="agent_container"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_AGENT} ${TAG_AGENT}"
+        rlRun "limeUpdateConf agent registrar_ip '\"$IP_ATTESTATION_SERVER\"'"
+        rlRun "limeUpdateConf agent trusted_client_ca '\"/var/lib/keylime/cv_ca/cacert.pem\"'"
+        rlRun "limeconPrepareAgentConfdir $AGENT_ID $IP_AGENT confdir_$CONT_AGENT"
+
+        # create allowlist and excludelist
+        TESTDIR=`limeCreateTestDir`
+        rlRun "limeCreateTestLists ${TESTDIR}/*"
+
+        rlRun "limeconRunAgent $CONT_AGENT $TAG_AGENT $IP_AGENT $CONT_NETWORK_NAME $PWD/confdir_$CONT_AGENT $TESTDIR"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent"
+        rlRun -s "keylime_tenant -v $IP_ATTESTATION_SERVER  -t $IP_AGENT -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c add"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        limeconSubmitLogs
+        rlRun "limeconStop $CONT_ATTESTATION_SERVER $CONT_AGENT"
+        rlRun "limeconDeleteNetwork $CONT_NETWORK_NAME"
+        #set tmp resource manager permission to default state
+        rlRun "chmod o-rw /dev/tpmrm0"
+        limeExtendNextExcludelist $TESTDIR
+        limeSubmitCommonLogs
+        limeClearData
+        limeRestoreConfig
+    rlPhaseEnd
+
+rlJournalEnd
+

--- a/functional/basic-attestation-with-postgresql-db/main.fmf
+++ b/functional/basic-attestation-with-postgresql-db/main.fmf
@@ -1,0 +1,40 @@
+summary: Tests basic keylime attestation scenario with keylime services using remote postgresql database
+description: |
+    Running only tenant on localhost. Verifier and Registrar run in container and agents run in container.
+    Configure and set up postgresql db so it can be used by keylime services.
+    Create new network for containers.
+    Build container image with verifier and registrar.
+    Run verifier and registrar container.
+    Download ansible playbook for keylime verifier and registrar roles.
+    Run ansible playbook to set up verifier and registrar to use postgresql db.
+    Build container image with agent.
+    Setup agent conf for agent container.
+    Run container with agent.
+    Register agent by verifier.
+    Verify that container passed with agent attestation.
+contact: Karel Srot <ksrot@redhat.com>
+tag:
+  - container
+component:
+  - keylime
+test: ./test.sh
+framework: beakerlib
+require:
+  - url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: rhel-9-main
+    name: /Library/test-helpers
+  - yum
+  - podman
+  - ansible-core
+  - nmap
+  - postgresql-server
+  - postgresql-contrib
+  - python3-psycopg2
+recommend:
+  - keylime
+duration: 10m
+enabled: true
+adjust:
+  - when: swtpm == yes
+    enabled: false
+    because: This tests needs TPM device since kernel boot

--- a/functional/basic-attestation-with-postgresql-db/setup.psql
+++ b/functional/basic-attestation-with-postgresql-db/setup.psql
@@ -1,0 +1,10 @@
+create database verifierdb;
+create user verifier with encrypted password 'fire';
+grant all privileges on database verifierdb to verifier;
+create database registrardb;
+create user registrar with encrypted password 'regi';
+grant all privileges on database registrardb to registrar;
+\connect verifierdb;
+grant all privileges on schema public to verifier;
+\connect registrardb;
+grant all privileges on schema public to registrar;

--- a/functional/basic-attestation-with-postgresql-db/test.sh
+++ b/functional/basic-attestation-with-postgresql-db/test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+[ -n "$DOCKERFILE_AGENT" ] || DOCKERFILE_AGENT=Dockerfile.agent
+[ -n "$DOCKERFILE_SYSTEMD" ] || DOCKERFILE_SYSTEMD=Dockerfile.systemd
+
+#Machine should have /dev/tpm0 or /dev/tpmrm0 device
+AGENT_ID="d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+
+rlJournalStart
+
+    rlPhaseStartSetup "Do the keylime setup"
+
+        rlRun 'rlImport "keylime-tests/test-helpers"'|| rlDie "cannot import /keylime-tests/test-helpers library"
+        rlAssertRpm keylime
+
+        # backup and configure postgresql db
+	rlRun "HOST_IP=\$(hostname -I | cut -d ' ' -f 1)"
+        rlServiceStop postgresql
+        rlFileBackup --clean --missing-ok /var/lib/pgsql /etc/postgresql-setup
+        rlRun "rm -rf /var/lib/pgsql/data"
+        rlRun "postgresql-setup --initdb --unit postgresql"
+        # configure user authentication with md5 and pgsql listening address
+        rlRun "sed -i \"s|^host.*all.*all.*127.0.0.1.*ident|host all all 0.0.0.0/0 md5|\" /var/lib/pgsql/data/pg_hba.conf"
+        rlRun "sed -i \"s|^#listen_addresses.*|listen_addresses = '0.0.0.0'|\" /var/lib/pgsql/data/postgresql.conf"
+        rlServiceStart postgresql
+        sleep 3
+        rlRun "sudo -u postgres psql -f setup.psql"
+
+        # update /etc/keylime.conf
+        limeBackupConfig
+        CONT_NETWORK_NAME="container_network"
+        IP_ATTESTATION_SERVER="172.18.0.4"
+        IP_AGENT="172.18.0.12"
+        #create network for containers
+        rlRun "limeconCreateNetwork ${CONT_NETWORK_NAME} 172.18.0.0/16"
+
+        #build verifier container
+        TAG_ATTESTATION_SERVER="attestation_server_image"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_SYSTEMD} ${TAG_ATTESTATION_SERVER}"
+
+        #mandatory for access agent containers to tpm
+        rlRun "chmod o+rw /dev/tpmrm0"
+
+        #run verifier container
+        CONT_ATTESTATION_SERVER="attestation_container"
+        rlRun "limeconRunSystemd $CONT_ATTESTATION_SERVER $TAG_ATTESTATION_SERVER $IP_ATTESTATION_SERVER $CONT_NETWORK_NAME"
+        rlRun "podman exec -t $CONT_ATTESTATION_SERVER dnf -y install python3-psycopg2"
+        rlRun "rm -rf roles && mkdir roles"
+        pushd roles
+        rlRun "GIT_SSL_NO_VERIFY=1 git clone https://gitlab.cee.redhat.com/keylime/attestation_server.git"
+        popd
+        rlRun "echo 172.18.0.4" > inventory
+        rlRun "cat > playbook.yml <<EOF
+- hosts: all
+  vars:
+    attestation_server_verifier_ip: \"{{ ansible_host }}\"
+    attestation_server_verifier_database_url: \"postgresql://verifier:fire@${HOST_IP}/verifierdb\"
+    attestation_server_registrar_ip: \"{{ ansible_host }}\"
+    attestation_server_registrar_database_url: \"postgresql://registrar:regi@${HOST_IP}/registrardb\"
+
+  roles:
+    - attestation_server
+EOF"
+        rlRun 'ansible-playbook --ssh-common-args "-o StrictHostKeychecking=no" -i inventory playbook.yml'
+        sleep 5
+        rlRun "rm -f /var/lib/keylime/cv_ca/*"
+        rlRun "podman cp $CONT_ATTESTATION_SERVER:/var/lib/keylime/cv_ca /var/lib/keylime/"
+
+        rlRun "limeWaitForVerifier 8881 $IP_ATTESTATION_SERVER"
+        rlRun "limeWaitForRegistrar 8891 $IP_ATTESTATION_SERVER"
+
+        #confirm that verifier and registrar accessed and modified databases
+        rlRun -s "sudo -u postgres psql -c 'SELECT datname FROM pg_database;'"
+        rlAssertGrep "verifierdb" $rlRun_LOG
+        rlAssertGrep "registrardb" $rlRun_LOG
+
+        # tenant
+        rlRun "limeUpdateConf tenant require_ek_cert False"
+        rlRun "limeUpdateConf tenant verifier_ip $IP_ATTESTATION_SERVER"
+        rlRun "limeUpdateConf tenant registrar_ip $IP_ATTESTATION_SERVER"
+
+        #setup of agent
+        rlRun "cp -r /var/lib/keylime/cv_ca ."
+        TAG_AGENT="agent_image"
+        CONT_AGENT="agent_container"
+        rlRun "limeconPrepareImage ${limeLibraryDir}/${DOCKERFILE_AGENT} ${TAG_AGENT}"
+        rlRun "limeUpdateConf agent registrar_ip '\"$IP_ATTESTATION_SERVER\"'"
+        rlRun "limeconPrepareAgentConfdir $AGENT_ID $IP_AGENT confdir_$CONT_AGENT"
+
+        # create allowlist and excludelist
+        TESTDIR=`limeCreateTestDir`
+        rlRun "limeCreateTestLists ${TESTDIR}/*"
+
+        rlRun "limeconRunAgent $CONT_AGENT $TAG_AGENT $IP_AGENT $CONT_NETWORK_NAME $PWD/confdir_$CONT_AGENT $TESTDIR"
+        rlRun "limeWaitForAgentRegistration ${AGENT_ID}"
+
+    rlPhaseEnd
+
+    rlPhaseStartTest "Add keylime agent"
+        rlRun -s "keylime_tenant -v $IP_ATTESTATION_SERVER  -t $IP_AGENT -u $AGENT_ID --allowlist allowlist.txt --exclude excludelist.txt -f excludelist.txt -c add"
+        rlRun "limeWaitForAgentStatus $AGENT_ID 'Get Quote'"
+        rlRun -s "keylime_tenant -c cvlist"
+        rlAssertGrep "{'code': 200, 'status': 'Success', 'results': {'uuids':.*'$AGENT_ID'" $rlRun_LOG -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "Do the keylime cleanup"
+        limeconSubmitLogs
+        rlRun "limeconStop $CONT_ATTESTATION_SERVER $CONT_AGENT"
+        rlRun "limeconDeleteNetwork $CONT_NETWORK_NAME"
+        #set tmp resource manager permission to default state
+        rlRun "chmod o-rw /dev/tpmrm0"
+        limeExtendNextExcludelist $TESTDIR
+        limeSubmitCommonLogs
+        limeClearData
+        limeRestoreConfig
+	rlServiceStop postgresql
+        rlFileRestore
+	rlServiceRestore postgresql
+    rlPhaseEnd
+
+rlJournalEnd

--- a/plans/system-roles.fmf
+++ b/plans/system-roles.fmf
@@ -1,0 +1,40 @@
+summary: run ansible system roles test with IMA policy setup
+
+environment:
+  DOCKERFILE_AGENT: Dockerfile.agent
+  DOCKERFILE_SYSTEMD: Dockerfile.systemd
+
+context:
+  swtpm: no
+  agent: rust
+
+provision:
+  hardware:
+    tpm:
+      version: "2"
+
+prepare:
+  - how: shell
+    script:
+     - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+    when: distro == rhel-9 or distro == centos-stream-9
+
+discover:
+  - name: Configure_simple_IMA_policy
+    how: fmf
+    url: https://github.com/RedHat-SP-Security/keylime-tests
+    ref: rhel-9-main
+    test:
+      - /setup/configure_kernel_ima_module/ima_policy_simple
+  - name: Run_ansible_system_roles_test
+    how: fmf
+    test:
+      - "/functional/.*"
+
+adjust:
+  - when: distro == rhel-8 or distro == centos-stream-8
+    enabled: false
+    because: keylime is not shipped for RHEL-8
+
+execute:
+  how: tmt


### PR DESCRIPTION
This is the initial setup:

- copy 3 existing system roles tests from internal gitlab
- add system-roles test plan
- enable Packit CI through `.packit.yaml`